### PR TITLE
Yet another fix of the build configs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,9 @@ publishLocal := {}
   */
 val suppressNameCheckUntilNextMajorVersion = semVerCheck := {
   version.value.split('.') match {
-    case Array("0", minor, _*) if minor.toInt <= 1 =>
-    case _ =>
+    case Array("0", minor, _*) if minor.toInt < 2 =>
+    case Array("0", "2", "0", _*) =>
+    case _ => // anything > 0.2.0
       throw new IllegalStateException("Version bump! It's time to re-enable semantic version validation.")
   }
 }
@@ -36,8 +37,6 @@ def commonProject(id: String, path: String): Project = {
       // disable scaladoc generation
       sources in(Compile, doc) := Seq.empty,
       publishArtifact in packageDoc := false,
-
-      publishMavenStyle := false,
 
       scalacOptions := scalacOptions.value
         .filterNot(_ == "-deprecation") ++ Seq(


### PR DESCRIPTION
@rallyhealth/engineers @sklei2 @mingy711 

I didn't calculate the fact that the previous build config would fail to publish v0.2.0 because of the error that states "Version bump!"

Also, it was a good thing, because I caught the fact that we would have been publishing in the wrong format. We should publish in maven format, not ivy.